### PR TITLE
Update runmode-dpdk.c

### DIFF
--- a/suricata-4.1.4/src/runmode-dpdk.c
+++ b/suricata-4.1.4/src/runmode-dpdk.c
@@ -29,7 +29,7 @@
  */
 
 //#include "dpdk-include-common.h"
-
+#include <config.h>
 #ifdef HAVE_DPDK
 #include <rte_common.h>
 #include <rte_byteorder.h>


### PR DESCRIPTION
fix runmode-dpdk.c compile error,add config.h include before rte headers include
without config.h include, HAVE_DPDK MACRO is disabled.